### PR TITLE
Adds placeholder to instance selector

### DIFF
--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -331,13 +331,14 @@ function Popup() {
                   >
                     <label className="contents">
                       <span className="px-8 text-12 text-gray">
-                        URL to open profiles with. Set as empty for default
-                        behavior.
+                        URL to open profiles with. Keep empty to open in
+                        the profile's Mastodon instance or fill in your own.
                       </span>
 
                       <input
                         spellCheck={false}
                         type="text"
+                        placeholder="https://mastodon.example/@{account}"
                         className="mx-8 rounded-6 border border-purple-light bg-gray-lightest px-6 py-2 text-12 text-cool-black"
                         ref={profileUrlSchemeInputRef}
                         defaultValue={profileUrlSchemeQuery.data}


### PR DESCRIPTION
### Changes
- Adds a placeholder to the URL field
- Improves help text

### Why?

As a user, I was initially confused as to why, when I entered my own home server (https://mastodon.design) the plugin just sent me home instead of to the profile that I was looking at.  After fiddling around with the examples, I found that the {account} flag had to be used for the desired behavior.  Hopefully adding a placeholder to the field with that text displayed will help new users like me in the future!

Thanks for the nice plugin! :)