### PR TITLE
Adds preliminary Bluesky support

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -35,6 +35,7 @@
     "zod": "^3.22.4"
   },
   "dependencies": {
+    "@atproto/api": "^0.13.29",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -321,6 +321,7 @@ function Popup() {
                           "mastodon.social",
                           "mona",
                           "phanpy",
+                          "bluesky",
                         ] as const
                       ).map((item) => {
                         return (
@@ -347,6 +348,7 @@ function Popup() {
                                     "https://mastodon.online/@{account}",
                                   mona: "mona:{profileUrl.noProtocol}",
                                   phanpy: `https://phanpy.social/#/https:{profileUrl.noProtocol}`,
+                                  bluesky: `https://bsky.app/profile/{account}`,
                                 }[item];
 
                                 profileUrlSchemeInputRef.current.focus();
@@ -361,6 +363,7 @@ function Popup() {
                                   "mastodon.online": "mastodon.online",
                                   mona: "Mona",
                                   phanpy: "Phanpy",
+                                  bluesky: "Bluesky",
                                 }[item]
                               }
                             </button>

--- a/extension/src/util/getUncachedProfileData.ts
+++ b/extension/src/util/getUncachedProfileData.ts
@@ -6,6 +6,7 @@ export async function getUncachedProfileData(
   href: string,
 ): Promise<Required<ProfileData>> {
   try {
+    // TODO: Add path for Bluesky
     if (!getIsUrlHttpOrHttps(href)) {
       throw new Error();
     }
@@ -22,71 +23,92 @@ export async function getUncachedProfileData(
       throw new Error();
     }
 
-    const visitedHrefResp = await fetch(href);
-    if (!visitedHrefResp.ok) {
-      throw new Error();
-    }
+    if (href.startsWith("https://bsky.app/profile")) {
+      const subjectAccount = removeSubstring(href, "https://bsky.app/profile/", 0);
+      const actor = subjectAccount.match ? subjectAccount.value : undefined
 
-    const visitedUrl = new URL(visitedHrefResp.url);
-
-    const webfingerUrl = new URL(visitedUrl.origin);
-    webfingerUrl.pathname = ".well-known/webfinger";
-    webfingerUrl.searchParams.set("resource", visitedUrl.toString());
-
-    const webfingerResp = await fetch(webfingerUrl);
-    if (!webfingerResp.ok) {
-      throw new Error();
-    }
-
-    const webfinger: Webfinger = await webfingerResp.json();
-
-    /**
-     * Account (username) of profile
-     */
-    let account: string | undefined;
-    {
-      const subjectAccount = removeSubstring(webfinger.subject, "acct:", 0);
-      if (subjectAccount.match) {
-        account = subjectAccount.value;
+      if (!actor) {
+        throw new Error();
       }
-    }
 
-    let profileUrl: string | undefined;
-    let avatar: string | undefined;
-    for (const webfingerLink of webfinger.links ?? []) {
-      if (!webfingerLink.href) {
-        continue;
+      const getProfileUrl = `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${actor}`
+
+      const getProfileResp = await fetch(getProfileUrl);
+      const profile = await getProfileResp.json()
+
+      return {
+        type: "profile",
+        account: actor + "@bsky.app",
+        profileUrl: href,
+        avatar: profile.avatar,
+      };
+    } else {
+      const visitedHrefResp = await fetch(href);
+      if (!visitedHrefResp.ok) {
+        throw new Error();
       }
-      switch (webfingerLink.rel) {
-        case "http://webfinger.net/rel/profile-page": {
-          try {
-            profileUrl = new URL(webfingerLink.href).toString();
-          } catch (err) {
-            // Do nothing
-          }
-          break;
-        }
-        case "http://webfinger.net/rel/avatar": {
-          try {
-            avatar = new URL(webfingerLink.href).toString();
-          } catch (err) {
-            // Do nothing
-          }
-          break;
+
+      const visitedUrl = new URL(visitedHrefResp.url);
+
+      const webfingerUrl = new URL(visitedUrl.origin);
+      webfingerUrl.pathname = ".well-known/webfinger";
+      webfingerUrl.searchParams.set("resource", visitedUrl.toString());
+
+      const webfingerResp = await fetch(webfingerUrl);
+      if (!webfingerResp.ok) {
+        throw new Error();
+      }
+
+      const webfinger: Webfinger = await webfingerResp.json();
+
+      /**
+       * Account (username) of profile
+       */
+      let account: string | undefined;
+      {
+        const subjectAccount = removeSubstring(webfinger.subject, "acct:", 0);
+        if (subjectAccount.match) {
+          account = subjectAccount.value;
         }
       }
-    }
 
-    if (!profileUrl) {
-      throw new Error();
-    }
+      let profileUrl: string | undefined;
+      let avatar: string | undefined;
+      for (const webfingerLink of webfinger.links ?? []) {
+        if (!webfingerLink.href) {
+          continue;
+        }
+        switch (webfingerLink.rel) {
+          case "http://webfinger.net/rel/profile-page": {
+            try {
+              profileUrl = new URL(webfingerLink.href).toString();
+            } catch (err) {
+              // Do nothing
+            }
+            break;
+          }
+          case "http://webfinger.net/rel/avatar": {
+            try {
+              avatar = new URL(webfingerLink.href).toString();
+            } catch (err) {
+              // Do nothing
+            }
+            break;
+          }
+        }
+      }
 
-    return {
-      type: "profile",
-      account,
-      profileUrl,
-      avatar,
-    };
+      if (!profileUrl) {
+        throw new Error();
+      }
+  
+      return {
+        type: "profile",
+        account,
+        profileUrl,
+        avatar,
+      };
+    }
   } catch (err) {
     return { type: "notProfile" };
   }

--- a/extension/src/util/getUncachedProfileData.ts
+++ b/extension/src/util/getUncachedProfileData.ts
@@ -6,7 +6,6 @@ export async function getUncachedProfileData(
   href: string,
 ): Promise<Required<ProfileData>> {
   try {
-    // TODO: Add path for Bluesky
     if (!getIsUrlHttpOrHttps(href)) {
       throw new Error();
     }

--- a/extension/src/util/getUncachedProfileData.ts
+++ b/extension/src/util/getUncachedProfileData.ts
@@ -1,3 +1,4 @@
+import { AtpAgent } from "@atproto/api"
 import { ProfileData, Webfinger } from "./constants";
 import { getIsUrlHttpOrHttps } from "./getIsUrlHttpOrHttps";
 import { removeSubstring } from "./removeSubstring";
@@ -30,10 +31,8 @@ export async function getUncachedProfileData(
         throw new Error();
       }
 
-      const getProfileUrl = `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${actor}`
-
-      const getProfileResp = await fetch(getProfileUrl);
-      const profile = await getProfileResp.json()
+      const agent = new AtpAgent({ service: 'https://public.api.bsky.app' })
+      const profile = (await agent.getProfile({ actor })).data
 
       return {
         type: "profile",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@atproto/api@npm:^0.13.29":
+  version: 0.13.29
+  resolution: "@atproto/api@npm:0.13.29"
+  dependencies:
+    "@atproto/common-web": "npm:^0.3.2"
+    "@atproto/lexicon": "npm:^0.4.5"
+    "@atproto/syntax": "npm:^0.3.1"
+    "@atproto/xrpc": "npm:^0.6.6"
+    await-lock: "npm:^2.2.2"
+    multiformats: "npm:^9.9.0"
+    tlds: "npm:^1.234.0"
+    zod: "npm:^3.23.8"
+  checksum: b44f744665dda0e3123bb17aa99bcf8cb15d5bd7f0b03827704a928944f7dfb0dcc2b0b48725e84a3645446ffb5b75a9a294923fcb793fe0a6d3f477bc805f14
+  languageName: node
+  linkType: hard
+
+"@atproto/common-web@npm:^0.3.2":
+  version: 0.3.2
+  resolution: "@atproto/common-web@npm:0.3.2"
+  dependencies:
+    graphemer: "npm:^1.4.0"
+    multiformats: "npm:^9.9.0"
+    uint8arrays: "npm:3.0.0"
+    zod: "npm:^3.23.8"
+  checksum: 54984d47947ed1f539ce88136a155e32e5229198ec251c439b83a8d8125a2f46e5725e5a82ce2389009e00851bc40c94b63daf8dea9503c5e3ef68044ff02b64
+  languageName: node
+  linkType: hard
+
+"@atproto/lexicon@npm:^0.4.5":
+  version: 0.4.5
+  resolution: "@atproto/lexicon@npm:0.4.5"
+  dependencies:
+    "@atproto/common-web": "npm:^0.3.2"
+    "@atproto/syntax": "npm:^0.3.1"
+    iso-datestring-validator: "npm:^2.2.2"
+    multiformats: "npm:^9.9.0"
+    zod: "npm:^3.23.8"
+  checksum: 5cb26d6d76cf2140dc91f9c5b146449656ef316bfb4f9b0c2b0d74298b5ffb1962b29f8c8743dda63f302abee5d504850ea847fc83bee4f9a89de57e28b3f393
+  languageName: node
+  linkType: hard
+
+"@atproto/syntax@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@atproto/syntax@npm:0.3.1"
+  checksum: 22139c4472559d8627017b7c3395346f35a240e09d01ec206fd06e4cbb54cd3348e007f26f1985a808bf7210b629e7cc0c9d149697db24e1a56be33143edec54
+  languageName: node
+  linkType: hard
+
+"@atproto/xrpc@npm:^0.6.6":
+  version: 0.6.6
+  resolution: "@atproto/xrpc@npm:0.6.6"
+  dependencies:
+    "@atproto/lexicon": "npm:^0.4.5"
+    zod: "npm:^3.23.8"
+  checksum: 8f0ac9f93fa7b5ce8c7507295d8839edff1a4d8273061bf5c63e220d41320371731ed9ad77045d86893fe95f1a2915296c2da304be65436a80ae3a9e1422df5c
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/code-frame@npm:7.23.5"
@@ -1890,6 +1948,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"await-lock@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "await-lock@npm:2.2.2"
+  checksum: bedf00dad44c6325a655bf3bd523ab9e1ce41023da6a8c379990c76ac1d942ac7e5301627ab84ba37917ab5247506ba429b7f6e4bf77074093f255571b9ad5ee
+  languageName: node
+  linkType: hard
+
 "axe-core@npm:=4.7.0":
   version: 4.7.0
   resolution: "axe-core@npm:4.7.0"
@@ -2845,6 +2910,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "extension-3b1fc9@workspace:extension"
   dependencies:
+    "@atproto/api": "npm:^0.13.29"
     "@radix-ui/colors": "npm:^3.0.0"
     "@radix-ui/react-popover": "npm:^1.0.7"
     "@radix-ui/react-tabs": "npm:^1.0.4"
@@ -3669,6 +3735,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"iso-datestring-validator@npm:^2.2.2":
+  version: 2.2.2
+  resolution: "iso-datestring-validator@npm:2.2.2"
+  checksum: 34f05a6ac62f311feda19328c033d94a2a52789d07b9863fec304ed11f69f8bba7922dc6fef5b88a53bd722ddfd9446a2433cb29459885549f69af16672b6f74
+  languageName: node
+  linkType: hard
+
 "iterator.prototype@npm:^1.1.2":
   version: 1.1.2
   resolution: "iterator.prototype@npm:1.1.2"
@@ -4057,6 +4130,13 @@ __metadata:
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^9.4.2, multiformats@npm:^9.9.0":
+  version: 9.9.0
+  resolution: "multiformats@npm:9.9.0"
+  checksum: 1fdb34fd2fb085142665e8bd402570659b50a5fae5994027e1df3add9e1ce1283ed1e0c2584a5c63ac0a58e871b8ee9665c4a99ca36ce71032617449d48aa975
   languageName: node
   linkType: hard
 
@@ -5357,6 +5437,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tlds@npm:^1.234.0":
+  version: 1.255.0
+  resolution: "tlds@npm:1.255.0"
+  bin:
+    tlds: bin.js
+  checksum: e7e0434142a2ee80e48c383db53cc94757a9fefd545230fad908a31c235f9f9b9cd1d8232d9bc2bd018050f0e8a912c141d0c79289dda852169199892ba847d0
+  languageName: node
+  linkType: hard
+
 "to-fast-properties@npm:^2.0.0":
   version: 2.0.0
   resolution: "to-fast-properties@npm:2.0.0"
@@ -5500,6 +5589,15 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 1d0a5f4ce496c42caa9a30e659c467c5686eae15d54b027ee7866744952547f1be1262f2d40de911618c242b510029d51d43ff605dba8fb740ec85ca2d3f9500
+  languageName: node
+  linkType: hard
+
+"uint8arrays@npm:3.0.0":
+  version: 3.0.0
+  resolution: "uint8arrays@npm:3.0.0"
+  dependencies:
+    multiformats: "npm:^9.4.2"
+  checksum: 19efb7d2ba20ec2550d1ca5b453c01ad62e70098e6454d0a446b12991fa5f3286f8ee979e5cec020fac6b4cbbaad4597024dcc8b2c69365af95443cce1323e34
   languageName: node
   linkType: hard
 
@@ -5828,5 +5926,12 @@ __metadata:
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.23.8":
+  version: 3.24.1
+  resolution: "zod@npm:3.24.1"
+  checksum: 0223d21dbaa15d8928fe0da3b54696391d8e3e1e2d0283a1a070b5980a1dbba945ce631c2d1eccc088fdbad0f2dfa40155590bf83732d3ac4fcca2cc9237591b
   languageName: node
   linkType: hard


### PR DESCRIPTION
- Adds support to parse Bluesky profile links. It gets Bluesky profile information from a public API [endpoint](https://docs.bsky.app/docs/api/app-bsky-actor-get-profile).
- The documentation/branding still needs to be updated to reference Bluesky
- @atproto/api [README](https://github.com/bluesky-social/atproto/tree/d80380cb5686f30aa9d23b67f5db69ec161b265a/packages/api)
- The [type definition](https://github.com/bluesky-social/atproto/blob/d80380cb5686f30aa9d23b67f5db69ec161b265a/packages/api/src/client/types/app/bsky/actor/defs.ts#L62) of the response

![image](https://github.com/user-attachments/assets/9d5a5e46-8f15-4236-9e5e-172fac1834d5)